### PR TITLE
feat: support single-step advancement

### DIFF
--- a/examples/chat/package-lock.json
+++ b/examples/chat/package-lock.json
@@ -18,11 +18,11 @@
     },
     "../..": {
       "name": "@dylibso/mcpx-openai",
-      "version": "0.0.3",
+      "version": "0.0.7",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@dylibso/mcpx": "^0.21.0",
-        "openai": "^4.7",
+        "@dylibso/mcpx": "^0.27.0",
+        "openai": "^4.83.0",
         "pino": "^9.6.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dist"
   ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "build": "node esbuild.js",
     "postbuild": "npm run build:types",
     "prepare": "npm run build",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { McpxOpenAI } from './openai.ts';
+export { McpxOpenAI, ToolSchemaError } from './openai.ts';

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -203,10 +203,6 @@ export class ToolSchemaError extends Error {
   public readonly toolIndex: number
   constructor(error: any, index: number) {
     super(error.message)
-
-    // Required for instanceof https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
-    Object.setPrototypeOf(this, ToolSchemaError.prototype);
-
     this.originalError = error;
     this.toolIndex = index;
   }

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -192,7 +192,7 @@ export class ToolSchemaError extends Error {
       const regex = /tools\[(\d+)\]\.function\.parameters/;
       const match = error.param?.match(regex);
       if (match) {
-        const index = match ? parseInt(match[1]) : -1
+        const index = parseInt(match[1], 10) || -1
         return new ToolSchemaError(err, index)
       }
     }

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -88,7 +88,7 @@ export class McpxOpenAI {
     let messageIdx = 1
     do {
       const result =
-        await this.chatCompletionStep({
+        await this.nextTurn({
           ...rest,
           ...(this.#tools.length ? { tools: this.#tools } : {}),
           messages,
@@ -104,7 +104,7 @@ export class McpxOpenAI {
     return response
   }
 
-  async chatCompletionStep(
+  async nextTurn(
     body: ChatCompletionCreateParamsNonStreaming,
     messageIdx: number,
     options?: RequestOptions<unknown> | undefined,

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -88,7 +88,12 @@ export class McpxOpenAI {
     let messageIdx = 1
     do {
       const result =
-        await this.chatCompletionStep(body, messageIdx, options)
+        await this.chatCompletionStep({
+          ...rest,
+          ...(this.#tools.length ? { tools: this.#tools } : {}),
+          messages,
+        }, messageIdx, options)
+      
       response = result.response
       messages = result.messages
       messageIdx = result.index

--- a/test/toolSchemaError.test.ts
+++ b/test/toolSchemaError.test.ts
@@ -1,0 +1,97 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { ToolSchemaError } from '../src/openai.ts';
+
+describe('ToolSchemaError', () => {
+  describe('parse', () => {
+    test('should return original error if not a tool schema error', () => {
+      const originalError = new Error('Not a schema error');
+      assert.strictEqual(ToolSchemaError.parse(originalError), originalError);
+    });
+
+    test('should return original error if error type is not invalid_request_error', () => {
+      const originalError = { 
+        error: { 
+          type: 'other_error', 
+          code: 'invalid_function_parameters',
+          param: 'tools[0].function.parameters',
+          message: 'Some error message' 
+        }
+      };
+      assert.strictEqual(ToolSchemaError.parse(originalError), originalError);
+    });
+
+    test('should return original error if code is not invalid_function_parameters', () => {
+      const originalError = { 
+        error: { 
+          type: 'invalid_request_error', 
+          code: 'other_error',
+          param: 'tools[0].function.parameters',
+          message: 'Some error message' 
+        }
+      };
+      assert.strictEqual(ToolSchemaError.parse(originalError), originalError);
+    });
+
+    test('should return original error if param does not match the tools pattern', () => {
+      const originalError = { 
+        error: { 
+          type: 'invalid_request_error', 
+          code: 'invalid_function_parameters',
+          param: 'not_tools_pattern',
+          message: 'Some error message' 
+        }
+      };
+      assert.strictEqual(ToolSchemaError.parse(originalError), originalError);
+    });
+
+    test('should return a ToolSchemaError when conditions are met', () => {
+      const originalError = { 
+        error: {
+          type: 'invalid_request_error',
+          param: 'tools[2].function.parameters',
+          code: 'invalid_function_parameters',
+          message: 'The parameters for function tools[2].function.parameters are invalid'
+        },
+        message: 'Original error message'
+      };
+      
+      const result = ToolSchemaError.parse(originalError);
+      
+      assert.ok(result instanceof ToolSchemaError);
+      assert.strictEqual(result.originalError, originalError);
+      assert.strictEqual(result.toolIndex, 2);
+    });
+  });
+
+  describe('constructor', () => {
+    test('should set originalError and toolIndex properties', () => {
+      const originalError = new Error('Test error');
+      const toolIndex = 3;
+      
+      const error = new ToolSchemaError(originalError, toolIndex);
+      
+      assert.strictEqual(error.originalError, originalError);
+      assert.strictEqual(error.toolIndex, toolIndex);
+    });
+
+    test('should use the error message from the original error', () => {
+      const originalError = new Error('Test error message');
+      const toolIndex = 1;
+      
+      const error = new ToolSchemaError(originalError, toolIndex);
+      
+      assert.strictEqual(error.message, originalError.message);
+    });
+
+    test('should properly maintain instanceof checks', () => {
+      const originalError = new Error('Test error');
+      const toolIndex = 0;
+      
+      const error = new ToolSchemaError(originalError, toolIndex);
+      
+      assert.ok(error instanceof ToolSchemaError);
+      assert.ok(error instanceof Error);
+    });
+  });
+});

--- a/test/toolschema.test.js
+++ b/test/toolschema.test.js
@@ -1,0 +1,10 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { ToolSchemaError } from '../dist/index.js';
+
+describe('ToolSchemaError JS compatibility', () => {
+  test('should be instanceof ToolSchemaError', () => {
+    // Verify we don't need to explicitly Object.setPrototypeOf(this, ToolSchemaError.prototype);
+    assert.ok(new ToolSchemaError(new Error(), 0) instanceof ToolSchemaError)
+  })
+})


### PR DESCRIPTION
introduce `chatCompletionStep()`, this allows to evaluate a single response, perform tool invocations and return the current cursor index.

