### PR TITLE
feat: support mid-turn advancement

### DIFF
--- a/src/openai.ts
+++ b/src/openai.ts
@@ -163,7 +163,7 @@ export class McpxOpenAI {
     }
   }
 
-  private async next(stage: McpxOpenAIStage, config: any, requestOptions?: RequestOptions<unknown>): Promise<McpxOpenAIStage> {
+  async next(stage: McpxOpenAIStage, config: any, requestOptions?: RequestOptions<unknown>): Promise<McpxOpenAIStage> {
     const { response, messages, index, status } = stage
 
     // Read the current message in the batch.

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -276,7 +276,7 @@ export class ToolSchemaError extends Error {
   public readonly toolIndex: number
   public readonly toolName: string
   constructor(error: any, index: number, name: string) {
-    super(error.message)
+    super(`Invalid schema for tool #${index}: '${name}'\nCaused by: ${error.message}`)
     this.originalError = error;
     this.toolIndex = index;
     this.toolName = name;

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -177,7 +177,7 @@ export class McpxOpenAI {
             messages,
           }, requestOptions)
         } catch (err: any) {
-          throw ToolSchemaError.parse(err)
+          throw ToolSchemaError.parse(err, this.#tools)
         }
 
         // Note: `response.choices.length` is always 1 if option `n` is 1
@@ -256,7 +256,7 @@ export class McpxOpenAI {
 }
 
 export class ToolSchemaError extends Error {
-  static parse(err: any): any {
+  static parse(err: any, tools: OpenAITool[]): any {
     console.log(JSON.stringify(err))
     const error = err?.error
     const code = error?.code
@@ -266,7 +266,7 @@ export class ToolSchemaError extends Error {
       const match = error.param?.match(regex);
       if (match) {
         const index = parseInt(match[1], 10) || -1
-        return new ToolSchemaError(err, index)
+        return new ToolSchemaError(err, index, tools[index].function.name)
       }
     }
     return err
@@ -274,10 +274,12 @@ export class ToolSchemaError extends Error {
 
   public readonly originalError: any
   public readonly toolIndex: number
-  constructor(error: any, index: number) {
+  public readonly toolName: string
+  constructor(error: any, index: number, name: string) {
     super(error.message)
     this.originalError = error;
     this.toolIndex = index;
+    this.toolName = name;
   }
 
 }

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -27,7 +27,7 @@ export interface McpxOpenAIStage {
   index: number
   toolCallIndex?: number
   status: 'ready' | 'pending' | 'input_wait'
-  response?: ChatCompletion
+  response: ChatCompletion
 }
 
 interface OpenAITool {
@@ -118,7 +118,7 @@ export class McpxOpenAI {
     }
     this.#logger.info({ lastMessage: messages[messageIdx] }, 'final message')
   }
-  
+
   async nextTurn(
     body: ChatCompletionCreateParamsNonStreaming,
     messageIdx: number,
@@ -167,7 +167,7 @@ export class McpxOpenAI {
   }
 
   private async next(stage: McpxOpenAIStage, config: any, requestOptions?: RequestOptions<unknown>): Promise<McpxOpenAIStage> {
-    const { messages, index, status } = stage
+    const { response, messages, index, status } = stage
 
     // Read the current message in the batch.
     switch (status) {
@@ -212,11 +212,11 @@ export class McpxOpenAI {
         const toolCalls = message.tool_calls!
         const tool = toolCalls[toolCallIndex]
         if (tool.type !== 'function') {
-          return { messages, index, status: 'pending' }
+          return { response, messages, index, status: 'pending' }
         }
 
         messages.push(await this.call(tool))
-        return { messages, index, status: 'input_wait', toolCallIndex: toolCallIndex + 1 }
+        return { response, messages, index, status: 'input_wait', toolCallIndex: toolCallIndex + 1 }
       }
       default:
         throw new Error("Illegal status: " + status)

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -204,13 +204,10 @@ export class McpxOpenAI {
       case 'input_wait': {
         const toolCallIndex = stage.toolCallIndex!
         const inputMessage = messages[index-1]
-        this.#logger.info({ m:"message index", index, len: messages.length })
 
         const message = inputMessage as ChatCompletionMessage
         const toolCalls = message.tool_calls!
         const tool = toolCalls[toolCallIndex]
-
-        this.#logger.info(toolCalls)
 
         if (tool.type !== 'function') {
           return { response, messages, index, status: 'pending' }
@@ -221,7 +218,7 @@ export class McpxOpenAI {
         if (nextTool >= toolCalls.length) {
           return { response, messages, index, status: 'pending' }
         } else {
-          return { response, messages, index, status: 'input_wait', toolCallIndex: toolCallIndex + 1 }
+          return { response, messages, index, status: 'input_wait', toolCallIndex: nextTool }
         }
       }
       default:

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -203,17 +203,26 @@ export class McpxOpenAI {
       }
       case 'input_wait': {
         const toolCallIndex = stage.toolCallIndex!
-        const inputMessage = messages[index]
+        const inputMessage = messages[index-1]
+        this.#logger.info({ m:"message index", index, len: messages.length })
 
         const message = inputMessage as ChatCompletionMessage
         const toolCalls = message.tool_calls!
         const tool = toolCalls[toolCallIndex]
+
+        this.#logger.info(toolCalls)
+
         if (tool.type !== 'function') {
           return { response, messages, index, status: 'pending' }
         }
 
         messages.push(await this.call(tool))
-        return { response, messages, index, status: 'input_wait', toolCallIndex: toolCallIndex + 1 }
+        const nextTool = toolCallIndex + 1
+        if (nextTool >= toolCalls.length) {
+          return { response, messages, index, status: 'pending' }
+        } else {
+          return { response, messages, index, status: 'input_wait', toolCallIndex: toolCallIndex + 1 }
+        }
       }
       default:
         throw new Error("Illegal status: " + status)

--- a/test/toolSchemaError.test.ts
+++ b/test/toolSchemaError.test.ts
@@ -6,7 +6,7 @@ describe('ToolSchemaError', () => {
   describe('parse', () => {
     test('should return original error if not a tool schema error', () => {
       const originalError = new Error('Not a schema error');
-      assert.strictEqual(ToolSchemaError.parse(originalError), originalError);
+      assert.strictEqual(ToolSchemaError.parse(originalError, []), originalError);
     });
 
     test('should return original error if error type is not invalid_request_error', () => {
@@ -18,7 +18,7 @@ describe('ToolSchemaError', () => {
           message: 'Some error message' 
         }
       };
-      assert.strictEqual(ToolSchemaError.parse(originalError), originalError);
+      assert.strictEqual(ToolSchemaError.parse(originalError, []), originalError);
     });
 
     test('should return original error if code is not invalid_function_parameters', () => {
@@ -30,7 +30,7 @@ describe('ToolSchemaError', () => {
           message: 'Some error message' 
         }
       };
-      assert.strictEqual(ToolSchemaError.parse(originalError), originalError);
+      assert.strictEqual(ToolSchemaError.parse(originalError, []), originalError);
     });
 
     test('should return original error if param does not match the tools pattern', () => {
@@ -42,7 +42,7 @@ describe('ToolSchemaError', () => {
           message: 'Some error message' 
         }
       };
-      assert.strictEqual(ToolSchemaError.parse(originalError), originalError);
+      assert.strictEqual(ToolSchemaError.parse(originalError, []), originalError);
     });
 
     test('should return a ToolSchemaError when conditions are met', () => {
@@ -55,12 +55,20 @@ describe('ToolSchemaError', () => {
         },
         message: 'Original error message'
       };
-      
-      const result = ToolSchemaError.parse(originalError);
+
+      const tools = [
+        { function:{name: 'tool1'} },
+        { function:{name: 'tool2'} },
+        { function:{name: 'tool3'} },
+      ] as any[];
+
+
+      const result = ToolSchemaError.parse(originalError, tools);
       
       assert.ok(result instanceof ToolSchemaError);
       assert.strictEqual(result.originalError, originalError);
       assert.strictEqual(result.toolIndex, 2);
+      assert.strictEqual(result.toolName, 'tool3');
     });
   });
 
@@ -69,17 +77,18 @@ describe('ToolSchemaError', () => {
       const originalError = new Error('Test error');
       const toolIndex = 3;
       
-      const error = new ToolSchemaError(originalError, toolIndex);
+      const error = new ToolSchemaError(originalError, toolIndex, 'tool4');
       
       assert.strictEqual(error.originalError, originalError);
       assert.strictEqual(error.toolIndex, toolIndex);
+      assert.strictEqual(error.toolName, 'tool4');
     });
 
     test('should use the error message from the original error', () => {
       const originalError = new Error('Test error message');
       const toolIndex = 1;
       
-      const error = new ToolSchemaError(originalError, toolIndex);
+      const error = new ToolSchemaError(originalError, toolIndex, 'MyTool');
       
       assert.strictEqual(error.message, originalError.message);
     });
@@ -88,7 +97,7 @@ describe('ToolSchemaError', () => {
       const originalError = new Error('Test error');
       const toolIndex = 0;
       
-      const error = new ToolSchemaError(originalError, toolIndex);
+      const error = new ToolSchemaError(originalError, toolIndex, 'MyTool');
       
       assert.ok(error instanceof ToolSchemaError);
       assert.ok(error instanceof Error);

--- a/test/toolSchemaError.test.ts
+++ b/test/toolSchemaError.test.ts
@@ -69,6 +69,7 @@ describe('ToolSchemaError', () => {
       assert.strictEqual(result.originalError, originalError);
       assert.strictEqual(result.toolIndex, 2);
       assert.strictEqual(result.toolName, 'tool3');
+      assert.strictEqual(result.message, "Invalid schema for tool #2: 'tool3'\nCaused by: Original error message");
     });
   });
 
@@ -84,13 +85,13 @@ describe('ToolSchemaError', () => {
       assert.strictEqual(error.toolName, 'tool4');
     });
 
-    test('should use the error message from the original error', () => {
+    test('should include the error message from the original error', () => {
       const originalError = new Error('Test error message');
       const toolIndex = 1;
       
       const error = new ToolSchemaError(originalError, toolIndex, 'MyTool');
-      
-      assert.strictEqual(error.message, originalError.message);
+
+      assert.ok(error.message.includes(originalError.message));
     });
 
     test('should properly maintain instanceof checks', () => {

--- a/test/toolschema.test.js
+++ b/test/toolschema.test.js
@@ -5,6 +5,6 @@ import { ToolSchemaError } from '../dist/index.js';
 describe('ToolSchemaError JS compatibility', () => {
   test('should be instanceof ToolSchemaError', () => {
     // Verify we don't need to explicitly Object.setPrototypeOf(this, ToolSchemaError.prototype);
-    assert.ok(new ToolSchemaError(new Error(), 0) instanceof ToolSchemaError)
+    assert.ok(new ToolSchemaError(new Error(), 0, 'blah') instanceof ToolSchemaError)
   })
 })


### PR DESCRIPTION
follow up to #10 

introduce:

- McpxOpenAITurn
- repurpose McpxOpenAIStage to mean "mid-turn"
- introduce next(), which might interrupt mid-turn with a function call
- rewrite nextTurn() in terms of next()

additionally, we ensure we actually use the tool name when we throw an error (I did not realize in #10 we have the tool names available here).
