### PR TITLE
feat: forced result tool

### DIFF
--- a/src/openai.ts
+++ b/src/openai.ts
@@ -194,7 +194,7 @@ export class McpxOpenAI {
       case 'pending': {
         let response: ChatCompletion
         const tool_choice =
-          this.#forceTool? { type: 'function', function: { name: this.#forceTool } } : 'auto'
+          this.#forceTool && resultStatus === 'pending' ? { type: 'function', function: { name: this.#forceTool } } : 'auto'
         try {
           response = await this.#openai.chat.completions.create({
             ...config,
@@ -255,7 +255,7 @@ export class McpxOpenAI {
         const nextTool = toolCallIndex + 1
         if (nextTool >= toolCalls.length) {
           if (resultStatus === 'pending') {
-            return { response, messages, index, status: 'ready', resultStatus: 'ready' }
+            return { response, messages, index, status: 'pending', resultStatus: 'ready' }
           }
           return { response, messages, index, status: 'pending', resultStatus }
         } else {

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -194,7 +194,7 @@ export class McpxOpenAI {
       case 'pending': {
         let response: ChatCompletion
         const tool_choice =
-          this.#forceTool? { type: 'function', name: this.#forceTool } : 'auto'
+          this.#forceTool? { type: 'function', function: { name: this.#forceTool } } : 'auto'
         try {
           response = await this.#openai.chat.completions.create({
             ...config,

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -254,6 +254,9 @@ export class McpxOpenAI {
         messages.push(await this.call(tool))
         const nextTool = toolCallIndex + 1
         if (nextTool >= toolCalls.length) {
+          if (resultStatus === 'pending') {
+            return { response, messages, index, status: 'ready', resultStatus: 'ready' }
+          }
           return { response, messages, index, status: 'pending', resultStatus }
         } else {
           return { response, messages, index, status: 'input_wait', toolCallIndex: nextTool, resultStatus }

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -175,7 +175,7 @@ export class McpxOpenAI {
       case 'pending': {
         let response: ChatCompletion
         const tool_choice =
-          lastTurn? { type: 'function', name: this.#resultTool } : { type: 'auto' }
+          lastTurn? { type: 'function', name: this.#resultTool } : 'auto'
         try {
           response = await this.#openai.chat.completions.create({
             ...config,

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -204,11 +204,10 @@ export class McpxOpenAI {
           return { response, messages, index, status: 'pending' }
         }
         messages.push(await this.call(tool, toolCallId!))
-        const nextTool = toolCallIndex! + 1
-        if (nextTool >= toolCallLength!) {
+        if (toolCallIndex && toolCallIndex >= toolCallLength!) {
           return { response, messages, index, status: 'pending' }
         } else {
-          return { response, messages, index, status: 'input_wait', toolCallIndex: nextTool }
+          return { response, messages, index, status: 'input_wait', toolCallIndex }
         }
       }
       default:


### PR DESCRIPTION
allow passing an optional `config` to `next()`. The allowed keys are the openai config keys, plus:

- `tools: Tool[]` (an MCP tool def)
- `tool_choice?: string`, if present, the name of exactly one tool in the tool list (either the one provided, or the one returned by the session)

